### PR TITLE
fix Scalar type expected, array or object received and return mailstatus

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -256,7 +256,7 @@ class block_coupon_external extends external_api {
         $status = block_coupon\helper::mail_coupons($coupons, $email, $generatesinglepdfs,
                 false, false, $generatoroptions->batchid);
 
-        return $status;
+        return $status[0];
     }
 
     /**
@@ -365,7 +365,7 @@ class block_coupon_external extends external_api {
         $status = block_coupon\helper::mail_coupons($coupons, $email, $generatesinglepdfs,
                 false, false, $generatoroptions->batchid);
 
-        return $status;
+        return $status[0];
     }
 
     /**


### PR DESCRIPTION
The return of generate_coupons_for_course and generate_coupons_for_cohorts is defined as boolean, but this functions return an array.

This produces an invalid_response_exception.

Now it will return the mail status.