### PR TITLE
Fix greeting and signoff in e-mail templates.

### DIFF
--- a/lang/en/block_coupon.php
+++ b/lang/en/block_coupon.php
@@ -335,12 +335,12 @@ $string['default-coupon-page-template-botright'] = '<ol>
 <li>Happy learning!</li>
 </ol>';
 
-$string['coupon_mail_content'] = '<p>Dear {$a->to_name},</p>
+$string['coupon_mail_content'] = '<p>Dear {$a->fullname},</p>
 <p>You are receiving this message because there have been newly generated coupons.<br/>
 The coupons are available for download on the e-learning environment.<br /><br />
 Please click {$a->downloadlink} to get your coupons</p>
 <p>With kind regards,<br /><br />
-{$a->from_name}</p>';
+{$a->signoff}</p>';
 
 $string['coupon_mail_csv_content'] = '
 Dear ##to_gender## ##to_name##,<br /><br />
@@ -632,12 +632,12 @@ $string['label:generatecodesonly_help'] = 'If you enable this option, only codes
 This means the complete mailing option and creating PDFs will be skipped!';
 
 $string['generator:export:mail:subject'] = 'Coupons ready for download';
-$string['generator:export:mail:body'] = 'Dear {$a->to_name},<br /><br />
+$string['generator:export:mail:body'] = 'Dear {$a->fullname},<br /><br />
 You are receiving this message because there have been newly generated coupons.<br/>
 The coupons can be downloaded from {$a->downloadlink} (requires logging in to Moodle).<br />
 Please note this link can only be used once. After you\'ve downloaded the generated coupons, this link can no longer be used.<br />
 With kind regards,<br /><br />
-{$a->from_name}';
+{$a->signoff}';
 
 $string['error:already-enrolled-in-courses'] = 'You have already been enrolled in all courses';
 $string['error:already-enrolled-in-cohorts'] = 'You have already been enrolled in all cohorts';

--- a/lang/fr/block_coupon.php
+++ b/lang/fr/block_coupon.php
@@ -304,13 +304,13 @@ $string['default-coupon-page-template-botright'] = '<ol>
 </ol>';
 
 $string['coupon_mail_content'] = '
-Cher {$a->to_name},<br /><br />
+Cher {$a->fullname},<br /><br />
 
 Vous recevez ce message car il y a eu de nouveaux coupons de générés. Les coupons ont été ajoutés dans la pièce jointe à ce message.<br /><br />
 
 Cordialement,<br /><br />
 
-{$a->from_name}';
+{$a->signoff}';
 
 $string['coupon_mail_csv_content'] = '
 Cher ##to_gender## ##to_name##,<br /><br />

--- a/lang/nl/block_coupon.php
+++ b/lang/nl/block_coupon.php
@@ -335,12 +335,12 @@ $string['default-coupon-page-template-botright'] = '<ol>
 <li>Veel leerplezier!</li>
 </ol>';
 
-$string['coupon_mail_content'] = '<p>Beste {$a->to_name},</p>
+$string['coupon_mail_content'] = '<p>Beste {$a->fullname},</p>
 <p>U ontvangt dit bericht omdat er zojuist nieuwe Coupons zijn gegenereered.<br/>
 De coupons zijn als download beschikbaar gemaakt binnen de leeromgeving.<br /><br />
 Klik a.u.b {$a->downloadlink} om je coupons op te halen.</p>
 <p>Met vriendelijke groet,<br /><br />
-{$a->from_name}</p>';
+{$a->signoff}</p>';
 
 $string['coupon_mail_csv_content'] = '
 Beste ##to_gender## ##to_name##,<br /><br />


### PR DESCRIPTION
On generating coupons, I was getting e-mail without placeholders being substituted.  Literally,

```
Dear {$a->to_name},
You are receiving this message because [...]
With kind regards,

{$a->from_name}
```
(without any substitution for the placeholders)

This change uses the fullname/signoff placeholders instead of to_name/from_name, and the e-mail goes out successfully.

Cheers,
_Rob