### PR TITLE
Use format_string() to format course names.

### DIFF
--- a/classes/coupon/generator.php
+++ b/classes/coupon/generator.php
@@ -370,7 +370,7 @@ class generator implements icoupongenerator {
 
             $coursenames = array();
             foreach ($this->courses as $course) {
-                $coursenames[] = $course->fullname;
+                $coursenames[] = format_string($course->fullname);
             }
 
             $arrreplace[] = '##course_fullnames##';

--- a/classes/couponnotification.php
+++ b/classes/couponnotification.php
@@ -29,6 +29,7 @@
 
 namespace block_coupon;
 
+
 /**
  * block_coupon\couponnotification
  *
@@ -95,7 +96,7 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string($course->fullname);
         $a->signoff = generate_email_signoff();
         $a->batchid = $batchid;
         $a->downloadlink = \html_writer::link($downloadurl, get_string('here', 'block_coupon'));
@@ -143,7 +144,7 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string($course->fullname);
         $a->signoff = generate_email_signoff();
         $a->batchid = $batchid;
         $a->downloadlink = \html_writer::link($downloadurl, get_string('here', 'block_coupon'));
@@ -191,7 +192,7 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string($course->fullname);
         $a->signoff = generate_email_signoff();
         $a->timecreated = userdate($timeexecuted, get_string('strftimedate', 'langconfig'));
         $a->batchid = $batchid;

--- a/classes/forms/coupon/cohort/page2.php
+++ b/classes/forms/coupon/cohort/page2.php
@@ -95,7 +95,7 @@ class page2 extends \moodleform {
             if ($cohortcourses) {
                 $headingstr = array();
                 foreach ($cohortcourses as $course) {
-                    $headingstr[] = $course->fullname;
+                    $headingstr[] = format_string($course->fullname);
                 }
                 $mform->addElement('static', 'connected_courses',
                         get_string('label:connected_courses', 'block_coupon'), implode('<br/>', $headingstr));

--- a/classes/forms/coupon/cohort/page4.php
+++ b/classes/forms/coupon/cohort/page4.php
@@ -100,7 +100,7 @@ class page4 extends \moodleform {
             if ($cohortcourses = helper::get_courses_by_cohort($cohort->id)) {
                 $headingstr = array();
                 foreach ($cohortcourses as $course) {
-                    $headingstr[] = $course->fullname;
+                    $headingstr[] = format_string($course->fullname);
                 }
                 $mform->addElement('static', 'connected_courses',
                         get_string('label:connected_courses', 'block_coupon'), implode('<br/>', $headingstr));

--- a/classes/forms/coupon/course/page1.php
+++ b/classes/forms/coupon/course/page1.php
@@ -103,7 +103,7 @@ class page1 extends \moodleform {
         // And create data for multiselect.
         $arrcoursesselect = array();
         foreach ($courses as $course) {
-            $arrcoursesselect[$course->id] = $course->fullname;
+            $arrcoursesselect[$course->id] = format_string($course->fullname);
         }
 
         $options = ['multiple' => true, 'onlyvisible' => true];

--- a/classes/forms/coupon/course/page2.php
+++ b/classes/forms/coupon/course/page2.php
@@ -91,11 +91,12 @@ class page2 extends \moodleform {
             }
 
             // Build up groups.
-            if (!isset($groupoptions[$course->fullname])) {
-                $groupoptions[$course->fullname] = array();
+            $fullname = format_string($course->fullname);
+            if (!isset($groupoptions[$fullname])) {
+                $groupoptions[$fullname] = array();
             }
             foreach ($groups as $group) {
-                $groupoptions[$course->fullname][$group->id] = $group->name;
+                $groupoptions[$fullname][$group->id] = $group->name;
             }
         }
 

--- a/classes/forms/coupon/course/page4.php
+++ b/classes/forms/coupon/course/page4.php
@@ -101,9 +101,9 @@ class page4 extends \moodleform {
         $mform->addRule('redirect_url', get_string('required'), 'required');
         $mform->addHelpButton('redirect_url', 'label:redirect_url', 'block_coupon');
 
-        // Course fullname.
+        // Course fullnames.
         list($cinsql, $cparams) = $this->db()->get_in_or_equal($this->generatoroptions->courses);
-        $courses = implode('<br/>', $this->db()->get_fieldset_select('course', 'fullname', 'id ' . $cinsql, $cparams));
+        $courses = implode('<br/>', array_map('format_string', $this->db()->get_fieldset_select('course', 'fullname', 'id ' . $cinsql, $cparams)));
         $mform->addElement('static', 'coupon_courses', get_string('label:selected_courses', 'block_coupon'), $courses);
 
         $this->add_action_buttons(true, get_string('button:next', 'block_coupon'));

--- a/classes/forms/coupon/extendenrolment/page1.php
+++ b/classes/forms/coupon/extendenrolment/page1.php
@@ -70,7 +70,7 @@ class page1 extends \moodleform {
         // And create data for multiselect.
         $arrcoursesselect = array();
         foreach ($courses as $course) {
-            $arrcoursesselect[$course->id] = $course->fullname;
+            $arrcoursesselect[$course->id] = format_string($course->fullname);
         }
 
         $attributes = array('size' => min(20, count($arrcoursesselect)));

--- a/classes/forms/coupon/extendenrolment/page3.php
+++ b/classes/forms/coupon/extendenrolment/page3.php
@@ -62,7 +62,7 @@ class page3 extends \moodleform {
         $a->duration = format_time($generatoroptions->enrolperiod);
         $a->courses = [];
         foreach ($courses as $course) {
-            $a->courses[] = $course->fullname;
+            $a->courses[] = format_string($course->fullname);
         }
         $a->courses = implode('<br/>', $a->courses);
         if (!empty($generatoroptions->emailto)) {

--- a/classes/forms/coupon/request/course.php
+++ b/classes/forms/coupon/request/course.php
@@ -75,7 +75,7 @@ class course extends \moodleform {
         $courses = $DB->get_records_list('course', 'id', $this->get_option($this->options, 'courses', []));
         $arrcoursesselect = array();
         foreach ($courses as $course) {
-            $arrcoursesselect[$course->id] = $course->fullname;
+            $arrcoursesselect[$course->id] = format_string($course->fullname);
         }
 
         $attributes = array('size' => min(20, count($arrcoursesselect)));

--- a/classes/forms/coursechooser.php
+++ b/classes/forms/coursechooser.php
@@ -74,11 +74,11 @@ class coursechooser extends \moodleform {
         // Add choices.
         if ($this->coursegrouping->maxamount == 1) {
             foreach ($this->courses as $course) {
-                $mform->addElement('radio', 'course', '', $course->fullname, $course->id);
+                $mform->addElement('radio', 'course', '', format_string($course->fullname), $course->id);
             }
         } else {
             foreach ($this->courses as $course) {
-                $mform->addElement('advcheckbox', "course[{$course->id}]", '', $course->fullname);
+                $mform->addElement('advcheckbox', "course[{$course->id}]", '', format_string($course->fullname));
             }
         }
 

--- a/classes/forms/element/findcohortcourses.php
+++ b/classes/forms/element/findcohortcourses.php
@@ -115,7 +115,7 @@ class findcohortcourses extends findcourses {
         $toselect = array();
         $courses = $this->load_courses();
         foreach ($courses as $id => $coursefullname) {
-            $optionname = $coursefullname;
+            $optionname = format_string($coursefullname);
             $this->addOption($optionname, $id, ['selected' => 'selected']);
             array_push($toselect, $id);
         }
@@ -124,7 +124,7 @@ class findcohortcourses extends findcourses {
     }
 
     /**
-     * Load courses based on cohorot setting.
+     * Load courses based on cohort setting.
      *
      * @return array
      */

--- a/classes/output/component/cleanupconfirm.php
+++ b/classes/output/component/cleanupconfirm.php
@@ -30,6 +30,7 @@
 
 namespace block_coupon\output\component;
 
+
 /**
  * block_coupon\manager\cleanupconfirm
  *
@@ -96,7 +97,7 @@ class cleanupconfirm implements \renderable, \templatable {
                 if (!empty($this->data->course)) {
                     $records = $DB->get_records_list('course', 'id', $this->data->course, 'fullname ASC', 'id,fullname');
                     foreach ($records as $record) {
-                        $data->deletestrings[] = $record->fullname;
+                        $data->deletestrings[] = format_string($record->fullname);
                     }
                 }
                 break;

--- a/view/signup.php
+++ b/view/signup.php
@@ -100,7 +100,7 @@ if ($mformsignup->is_cancelled()) {
     $emailconfirm = get_string('emailconfirm');
     $PAGE->navbar->add($emailconfirm);
     $PAGE->set_title($emailconfirm);
-    $PAGE->set_heading($PAGE->course->fullname);
+    $PAGE->set_heading(format_string($PAGE->course->fullname));
     echo $OUTPUT->header();
     notice(get_string('emailconfirmsent', '', $user->email), "$CFG->wwwroot/index.php");
     exit; // Never reached.


### PR DESCRIPTION
This request calls Moodle's `format_string()` whenever a course name is displayed, similarly to how Moodle does it internally everywhere.  This allows for filters to be run over course names.  (For example, course names using filter_multilang2 will be displayed in the user's own language.  This is how I tested the change locally.)

Cheers,
_Rob
