### PR TITLE
Use format_string() to format course names (updated)

### DIFF
--- a/classes/coupon/generator.php
+++ b/classes/coupon/generator.php
@@ -375,7 +375,14 @@ class generator implements icoupongenerator {
 
             $coursenames = array();
             foreach ($this->courses as $course) {
-                $coursenames[] = $course->fullname;
+                $coursenames[] = format_string(
+                    $course->fullname,
+                    true,
+                    [
+                        'filter' => true,
+                        'context' => \context_course::instance($course->id)
+                    ]
+                );
             }
 
             $arrreplace[] = '##course_fullnames##';

--- a/classes/couponnotification.php
+++ b/classes/couponnotification.php
@@ -29,6 +29,7 @@
 
 namespace block_coupon;
 
+
 /**
  * block_coupon\couponnotification
  *
@@ -95,7 +96,14 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string(
+            $course->fullname,
+            true,
+            [
+                'filter' => true,
+                'context' => \context_course::instance($course->id)
+            ]
+        );
         $a->signoff = generate_email_signoff();
         $a->batchid = $batchid;
         $a->downloadlink = \html_writer::link($downloadurl, get_string('here', 'block_coupon'));
@@ -143,7 +151,14 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string(
+            $course->fullname,
+            true,
+            [
+                'filter' => true,
+                'context' => \context_course::instance($course->id)
+            ]
+        );
         $a->signoff = generate_email_signoff();
         $a->batchid = $batchid;
         $a->downloadlink = \html_writer::link($downloadurl, get_string('here', 'block_coupon'));
@@ -191,7 +206,14 @@ class couponnotification {
 
         $a = new \stdClass();
         $a->fullname = fullname($recipient);
-        $a->course = $course->fullname;
+        $a->course = format_string(
+            $course->fullname,
+            true,
+            [
+                'filter' => true,
+                'context' => \context_course::instance($course->id)
+            ]
+        );
         $a->signoff = generate_email_signoff();
         $a->timecreated = userdate($timeexecuted, get_string('strftimedate', 'langconfig'));
         $a->batchid = $batchid;

--- a/classes/forms/coupon/cohort/cohortcourses.php
+++ b/classes/forms/coupon/cohort/cohortcourses.php
@@ -77,7 +77,14 @@ class cohortcourses extends baseform {
             if ($cohortcourses) {
                 $headingstr = array();
                 foreach ($cohortcourses as $course) {
-                    $headingstr[] = $course->fullname;
+                    $headingstr[] = format_string(
+                        $course->fullname,
+                        true,
+                        [
+                            'filter' => true,
+                            'context' => \context_course::instance($course->id)
+                        ]
+                    );
                 }
                 $mform->addElement('static', 'connected_courses',
                         get_string('label:connected_courses', 'block_coupon'), implode('<br/>', $headingstr));

--- a/classes/forms/coupon/course/coursegroups.php
+++ b/classes/forms/coupon/course/coursegroups.php
@@ -73,11 +73,19 @@ class coursegroups extends baseform {
             }
 
             // Build up groups.
-            if (!isset($groupoptions[$course->fullname])) {
-                $groupoptions[$course->fullname] = array();
+            $fullname = format_string(
+                $course->fullname,
+                true,
+                [
+                    'filter' => true,
+                    'context' => \context_course::instance($course->id)
+                ]
+            );
+            if (!isset($groupoptions[$fullname])) {
+                $groupoptions[$fullname] = array();
             }
             foreach ($groups as $group) {
-                $groupoptions[$course->fullname][$group->id] = $group->name;
+                $groupoptions[$fullname][$group->id] = $group->name;
             }
         }
 

--- a/classes/forms/coupon/extendenrolment/coursevars.php
+++ b/classes/forms/coupon/extendenrolment/coursevars.php
@@ -64,7 +64,14 @@ class coursevars extends baseform {
         // And create data for multiselect.
         $arrcoursesselect = array();
         foreach ($courses as $course) {
-            $arrcoursesselect[$course->id] = $course->fullname;
+            $arrcoursesselect[$course->id] = format_string(
+                $course->fullname,
+                true,
+                [
+                    'filter' => true,
+                    'context' => \context_course::instance($course->id)
+                ]
+            );
         }
 
         $attributes = array('size' => min(20, count($arrcoursesselect)));

--- a/classes/forms/coupon/request/course.php
+++ b/classes/forms/coupon/request/course.php
@@ -75,7 +75,14 @@ class course extends \moodleform {
         $courses = $DB->get_records_list('course', 'id', $this->get_option($this->options, 'courses', []));
         $arrcoursesselect = array();
         foreach ($courses as $course) {
-            $arrcoursesselect[$course->id] = $course->fullname;
+            $arrcoursesselect[$course->id] = format_string(
+                $course->fullname,
+                true,
+                [
+                    'filter' => true,
+                    'context' => \context_course::instance($course->id)
+                ]
+            );
         }
 
         $attributes = array('size' => min(20, count($arrcoursesselect)));

--- a/classes/forms/coursechooser.php
+++ b/classes/forms/coursechooser.php
@@ -74,11 +74,27 @@ class coursechooser extends \moodleform {
         // Add choices.
         if ($this->coursegrouping->maxamount == 1) {
             foreach ($this->courses as $course) {
-                $mform->addElement('radio', 'course', '', $course->fullname, $course->id);
+                $fullname = format_string(
+                    $course->fullname,
+                    true,
+                    [
+                        'filter' => true,
+                        'context' => \context_course::instance($course->id)
+                    ]
+                );
+                $mform->addElement('radio', 'course', '', $fullname, $course->id);
             }
         } else {
             foreach ($this->courses as $course) {
-                $mform->addElement('advcheckbox', "course[{$course->id}]", '', $course->fullname);
+                $fullname = format_string(
+                    $course->fullname,
+                    true,
+                    [
+                        'filter' => true,
+                        'context' => \context_course::instance($course->id)
+                    ]
+                );
+                $mform->addElement('advcheckbox', "course[{$course->id}]", '', $fullname);
             }
         }
 

--- a/classes/forms/element/findcohortcourses.php
+++ b/classes/forms/element/findcohortcourses.php
@@ -115,7 +115,14 @@ class findcohortcourses extends findcourses {
         $toselect = array();
         $courses = $this->load_courses();
         foreach ($courses as $id => $coursefullname) {
-            $optionname = $coursefullname;
+            $optionname = format_string(
+                $coursefullname,
+                true,
+                [
+                    'filter' => true,
+                    'context' => \context_course::instance($id)
+                ]
+            );
             $this->addOption($optionname, $id, ['selected' => 'selected']);
             array_push($toselect, $id);
         }
@@ -124,7 +131,7 @@ class findcohortcourses extends findcourses {
     }
 
     /**
-     * Load courses based on cohorot setting.
+     * Load courses based on cohort setting.
      *
      * @return array
      */

--- a/classes/output/component/cleanupconfirm.php
+++ b/classes/output/component/cleanupconfirm.php
@@ -30,6 +30,7 @@
 
 namespace block_coupon\output\component;
 
+
 /**
  * block_coupon\manager\cleanupconfirm
  *
@@ -96,7 +97,14 @@ class cleanupconfirm implements \renderable, \templatable {
                 if (!empty($this->data->course)) {
                     $records = $DB->get_records_list('course', 'id', $this->data->course, 'fullname ASC', 'id,fullname');
                     foreach ($records as $record) {
-                        $data->deletestrings[] = $record->fullname;
+                        $data->deletestrings[] = format_string(
+                            $record->fullname,
+                            true,
+                            [
+                                'filter' => true,
+                                'context' => \context_course::instance($record->id)
+                            ]
+                        );
                     }
                 }
                 break;

--- a/view/signup.php
+++ b/view/signup.php
@@ -100,7 +100,14 @@ if ($mformsignup->is_cancelled()) {
     $emailconfirm = get_string('emailconfirm');
     $PAGE->navbar->add($emailconfirm);
     $PAGE->set_title($emailconfirm);
-    $PAGE->set_heading($PAGE->course->fullname);
+    $PAGE->set_heading(format_string(
+        $PAGE->course->fullname,
+        true,
+        [
+            'filter' => true,
+            'context' => \context_course::instance($PAGE->course->id)
+        ]
+    ));
     echo $OUTPUT->header();
     notice(get_string('emailconfirmsent', '', $user->email), "$CFG->wwwroot/index.php");
     exit; // Never reached.


### PR DESCRIPTION
This updates @robjoyce PR to the HEAD of main, which applies the multilang filter to course names in emails and forms.

> Originally posted by @robjoyce on #12:
>
>This request calls Moodle's format_string() whenever a course name is displayed, similarly to how Moodle does it internally everywhere. This allows for filters to be run over course names. (For example, course names using filter_multilang2 will be displayed in the user's own language. This is how I tested the change locally.)