### PR TITLE
Fix deprecated warning when setting version and cron info.

### DIFF
--- a/block_coupon.php
+++ b/block_coupon.php
@@ -42,11 +42,7 @@ class block_coupon extends block_base {
      * initializes block
      */
     public function init() {
-        global $CFG;
         $this->title = get_string('blockname', 'block_coupon');
-        include($CFG->dirroot . '/blocks/coupon/version.php');
-        $this->version = $plugin->version;
-        $this->cron = $plugin->cron;
     }
 
     /**


### PR DESCRIPTION
This fixes #25 by removing the unnecessary code that sets the version and cron info (which was deprecated in Moodle when they moved to the version.php standard in [8571833f0bc](https://github.com/moodle/moodle/commit/8571833f0bc7fc0b4dc6e86171e2f8595eeddf89)).