### PR TITLE
Merge deprecated loggedin/loggedoff notification constants to single constant

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -31,14 +31,14 @@ defined('MOODLE_INTERNAL') || die();
 $messageproviders = [
     'coupon_task_notification' => [
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
             'anyotheroutput' => MESSAGE_PERMITTED,
         ],
     ],
     'coupon_notification' => [
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
             'email' => MESSAGE_DISALLOWED,
             'anyotheroutput' => MESSAGE_PERMITTED,
         ],


### PR DESCRIPTION
Fixes #32 where old `MESSAGE_DEFAULT_LOGGEDIN` and `MESSAGE_DEFAULT_LOGGEDOFF` notification constants are used in db/messages.php, these are converted to `MESSAGE_DEFAULT_ENABLED` as per the upgrade.txt in Moodle.

This breaks the DB upgrade in Moodle due to the use of these constants.